### PR TITLE
fix: change string key for activity title (req for interop with capac…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
                     android:name="com.google.android.gms.vision.DEPENDENCIES"
                     android:value="barcode" />
 
-            <activity android:label="@string/title_activity_main" android:name="com.dealrinc.gmvScanner.SecondaryActivity"/>
+            <activity android:label="@string/title_activity_barcode_scanner" android:name="com.dealrinc.gmvScanner.SecondaryActivity"/>
             <activity android:label="Read Barcode" android:name="com.dealrinc.gmvScanner.BarcodeCaptureActivity" android:theme="@style/Theme.AppCompat.Light"/>
         </config-file>
             
@@ -53,7 +53,7 @@
             <string name="permission_camera_rationale">Access to the camera is needed for detection</string>
             <string name="no_camera_permission">This application cannot run because it does not have the camera permission.  The application will now exit.</string>
             <string name="low_storage_error">Face detector dependencies cannot be downloaded due to low device storage</string>
-            <string name="title_activity_main">Barcode Reader Activity</string>
+            <string name="title_activity_barcode_scanner">Barcode Reader Activity</string>
             <string name="barcode_header">Click &quot;Read Barcode&quot; to read a barcode</string>
             <string name="read_barcode">Read Barcode</string>
             <string name="auto_focus">Auto Focus</string>


### PR DESCRIPTION
…itor)

in capacitor projects, the key "title_activity_main" is already used so we have to change it for this plugin to work (or to at least get a build running with it)